### PR TITLE
bulk contributions upload for all registered users

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,6 +505,7 @@ dependencies = [
  "serde_json",
  "starknet",
  "tokio",
+ "url",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,4 @@ tokio = { version = "1.18.2", features = ["full"] }
 async-trait = "0.1.56"
 mockall = "0.11.1"
 futures = {version = "0.3.21", features = ["alloc"]}
+url = "2.2.2"

--- a/src/bin/upload_pr.rs
+++ b/src/bin/upload_pr.rs
@@ -11,26 +11,22 @@ use deathnote_contributions_feeder::{
     traits::{fetcher::Fetcher, logger::Logger},
 };
 
+fn make_account() -> impl starknet::Account {
+    let private_key = env::var("PRIVATE_KEY").expect("PRIVATE_KEY must be set");
+    let account_address = env::var("ACCOUNT_ADDRESS").expect("ACCOUNT_ADDRESS must be set");
+    starknet::make_account(&private_key, &account_address)
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     env_logger::init();
     dotenv().ok();
     octocrab::initialise(octocrab::Octocrab::builder())?;
 
-    let private_key = env::var("PRIVATE_KEY").expect("PRIVATE_KEY must be set");
-    let account_address = env::var("ACCOUNT_ADDRESS").expect("ACCOUNT_ADDRESS must be set");
-    let oracle_contract_address =
-        env::var("METADATA_ADDRESS").expect("METADATA_ADDRESS must be set");
-    let registry_contract_address =
-        env::var("REGISTRY_ADDRESS").expect("REGISTRY_ADDRESS must be set");
-
     let database = database::API::default();
-    let starknet = starknet::API::new(
-        &private_key,
-        &account_address,
-        &oracle_contract_address,
-        &registry_contract_address,
-    );
+
+    let account = make_account();
+    let starknet = starknet::API::new(&account);
 
     let all = pullrequest::Filter::default(); // TODO filter only non up-to-date PR
 

--- a/src/bin/upload_pr.rs
+++ b/src/bin/upload_pr.rs
@@ -19,10 +19,18 @@ async fn main() -> Result<()> {
 
     let private_key = env::var("PRIVATE_KEY").expect("PRIVATE_KEY must be set");
     let account_address = env::var("ACCOUNT_ADDRESS").expect("ACCOUNT_ADDRESS must be set");
-    let contract_address = env::var("METADATA_ADDRESS").expect("METADATA_ADDRESS must be set");
+    let oracle_contract_address =
+        env::var("METADATA_ADDRESS").expect("METADATA_ADDRESS must be set");
+    let registry_contract_address =
+        env::var("REGISTRY_ADDRESS").expect("REGISTRY_ADDRESS must be set");
 
     let database = database::API::default();
-    let starknet = starknet::API::new(&private_key, &account_address, &contract_address);
+    let starknet = starknet::API::new(
+        &private_key,
+        &account_address,
+        &oracle_contract_address,
+        &registry_contract_address,
+    );
 
     let all = pullrequest::Filter::default(); // TODO filter only non up-to-date PR
 

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -122,7 +122,7 @@ impl Default for API {
 }
 
 #[async_trait]
-impl Logger<pullrequest::PullRequest, Result<()>> for API {
+impl Logger<pullrequest::PullRequest, ()> for API {
     async fn log(&self, pr: pullrequest::PullRequest) -> Result<()> {
         info!("Logging PR #{} by {} ({})", pr.id, pr.author, pr.status);
 
@@ -139,7 +139,7 @@ impl Logger<pullrequest::PullRequest, Result<()>> for API {
 }
 
 #[async_trait]
-impl Logger<repository::Repository, Result<()>> for API {
+impl Logger<repository::Repository, ()> for API {
     async fn log(&self, repo: repository::Repository) -> Result<()> {
         info!("Logging repository {}/{}", repo.owner, repo.name);
 
@@ -157,7 +157,7 @@ impl Logger<repository::Repository, Result<()>> for API {
 }
 
 #[async_trait]
-impl Logger<ContractUpdateStatus, Result<()>> for API {
+impl Logger<ContractUpdateStatus, ()> for API {
     async fn log(&self, status: ContractUpdateStatus) -> Result<()> {
         info!("Logging successful contract update for PR#{}", status.pr_id);
 
@@ -178,7 +178,7 @@ impl Fetcher<repository::Filter, repository::Repository> for API {
 }
 
 #[async_trait]
-impl Logger<repository::IndexingStatus, Result<()>> for API {
+impl Logger<repository::IndexingStatus, ()> for API {
     async fn log(&self, status: repository::IndexingStatus) -> Result<()> {
         info!(
             "Logging successful syncing for project {} ",

--- a/src/starknet/github_oracle.rs
+++ b/src/starknet/github_oracle.rs
@@ -1,0 +1,89 @@
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use log::info;
+use starknet::{
+    accounts::{Account, Call},
+    core::{
+        types::{AddTransactionResult, FieldElement},
+        utils::{cairo_short_string_to_felt, get_selector_from_name},
+    },
+};
+
+use super::models::ContractUpdateStatus;
+use crate::model::pullrequest;
+
+pub struct GithubOracle<'a, A: Account + Sync> {
+    oracle_contract_address: FieldElement,
+    account: &'a A,
+}
+
+fn oracle_contract_address() -> FieldElement {
+    let registry_contract_address =
+        std::env::var("METADATA_ADDRESS").expect("METADATA_ADDRESS must be set");
+    FieldElement::from_hex_be(&registry_contract_address)
+        .expect("Invalid value for METADATA_ADDRESS")
+}
+
+#[async_trait]
+pub trait Oracle {
+    async fn add_contribution(&self, pr: &pullrequest::PullRequest)
+        -> Result<ContractUpdateStatus>;
+
+    fn make_add_contribution_call(&self, pr: &pullrequest::PullRequest) -> Call;
+
+    async fn send_transaction(&self, calls: &Vec<Call>) -> Result<AddTransactionResult>;
+}
+
+impl<'a, A: Account + Sync> GithubOracle<'a, A> {
+    pub fn new(account: &'a A) -> Self {
+        Self {
+            oracle_contract_address: oracle_contract_address(),
+            account,
+        }
+    }
+}
+
+#[async_trait]
+impl<'a, A: Account + Sync> Oracle for GithubOracle<'a, A> {
+    async fn add_contribution(
+        &self,
+        pr: &pullrequest::PullRequest,
+    ) -> Result<ContractUpdateStatus> {
+        info!(
+            "Register contribution #{} by {} ({})",
+            pr.id, pr.author, pr.status
+        );
+
+        let transaction_result = self
+            .send_transaction(&vec![self.make_add_contribution_call(&pr)])
+            .await?;
+
+        Ok(ContractUpdateStatus::new(
+            pr.id.clone(),
+            format!("{:x}", transaction_result.transaction_hash),
+        ))
+    }
+
+    fn make_add_contribution_call(&self, pr: &pullrequest::PullRequest) -> Call {
+        Call {
+            to: self.oracle_contract_address,
+            selector: get_selector_from_name("add_contribution_from_handle").unwrap(),
+            calldata: vec![
+                FieldElement::from_dec_str(&pr.author).unwrap(), // github identifier
+                cairo_short_string_to_felt("").unwrap(),         // owner
+                cairo_short_string_to_felt(&pr.repository_id).unwrap(), // repo
+                FieldElement::from_dec_str(&pr.id).unwrap(),     // PR ID
+                FieldElement::from_dec_str(&pr.status.to_string()).unwrap(), // PR status (merged)
+            ],
+        }
+    }
+
+    async fn send_transaction(&self, calls: &Vec<Call>) -> Result<AddTransactionResult> {
+        info!("Sending transactions with {} calls", calls.len());
+
+        match self.account.execute(calls).send().await {
+            Ok(transaction_result) => Ok(transaction_result),
+            Err(error) => Err(anyhow!(error.to_string())),
+        }
+    }
+}

--- a/src/starknet/github_oracle.rs
+++ b/src/starknet/github_oracle.rs
@@ -60,7 +60,7 @@ impl<'a, A: Account + Sync> Oracle for GithubOracle<'a, A> {
 
         Ok(ContractUpdateStatus::new(
             pr.id.clone(),
-            format!("{:x}", transaction_result.transaction_hash),
+            format!("0x{:x}", transaction_result.transaction_hash),
         ))
     }
 

--- a/src/starknet/mod.rs
+++ b/src/starknet/mod.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use async_trait::async_trait;
+use futures::stream::{self, StreamExt};
 
 use log::debug;
 pub use starknet::accounts::Account;
@@ -17,7 +18,7 @@ use self::{
 };
 use crate::{
     model::pullrequest,
-    traits::Logger,
+    traits::{logger::StreamLogger, Streamable, StreamableResult},
 };
 
 mod github_oracle;
@@ -38,11 +39,17 @@ pub fn make_account(private_key: &str, account_address: &str) -> impl Account {
     )
 }
 
+fn nb_transactions_in_batch() -> usize {
+    std::env::var("NB_TRX_IN_BATCH")
+        .expect("NB_TRX_IN_BATCH should be set")
+        .parse::<usize>()
+        .expect("invalid value for NB_TRX_IN_BATCH")
 }
 
 pub struct API<'a> {
     registry: Registry,
     oracle: Box<dyn Oracle + Sync + Send + 'a>,
+    nb_transactions_in_batch: usize,
 }
 
 impl<'a> API<'a> {
@@ -50,17 +57,96 @@ impl<'a> API<'a> {
         Self {
             registry: Registry::default(),
             oracle: Box::new(GithubOracle::new(account)),
+            nb_transactions_in_batch: nb_transactions_in_batch(),
         }
     }
 
+    async fn next_prs_of_registered_users(
+        &self,
+        prs: &mut Streamable<'_, pullrequest::PullRequest>,
+    ) -> Vec<pullrequest::PullRequest> {
+        prs.filter_map(|pr| async {
+            if self.registry.is_user_registered(&pr.author).await {
+                Some(pr)
+            } else {
+                None
+            }
+        })
+        .take(self.nb_transactions_in_batch)
+        .collect::<Vec<_>>()
+        .await
+    }
 }
 
 #[async_trait]
-impl Logger<pullrequest::PullRequest, ContractUpdateStatus> for API {
-    async fn log(&self, pr: pullrequest::PullRequest) -> Result<ContractUpdateStatus> {
-        match self.is_user_registered(&pr.author).await {
-            true => self.send_contribution(pr).await,
-            false => Err(anyhow!("User {} not registered", &pr.author)),
-        }
+impl StreamLogger<pullrequest::PullRequest, ContractUpdateStatus> for API<'_> {
+    async fn log(
+        &self,
+        prs: Streamable<'life0, pullrequest::PullRequest>,
+    ) -> Result<StreamableResult<'life0, ContractUpdateStatus>> {
+        debug!("Logging contributions in smart contract");
+
+        struct State<'a>(
+            Streamable<'a, pullrequest::PullRequest>, // stream of contributions to upload
+            Option<Result<String>>,                   // Last transaction call result, if any
+            Vec<pullrequest::PullRequest>, // contributions sent in previous call for which we need to yield the status
+        );
+
+        let init_state = State(prs, None, Vec::new());
+
+        let status_stream = stream::unfold(init_state, |state| async {
+            let State(
+                mut next_contributions,
+                mut last_transaction_result,
+                mut contributions_uploaded,
+            ) = state;
+
+            loop {
+                if let Some(pr) = contributions_uploaded.pop() {
+                    // If we have some contributions left to flag, let's use the last call status to do so
+                    let result = match last_transaction_result.as_ref().unwrap() {
+                        Ok(hash) => Ok(ContractUpdateStatus::new(pr.id, hash.clone())),
+                        Err(error) => Err(anyhow::Error::msg(error.to_string())),
+                    };
+
+                    break Some((
+                        result,
+                        State(
+                            next_contributions,
+                            last_transaction_result,
+                            contributions_uploaded,
+                        ),
+                    ));
+                }
+
+                // No more current PRs, let's find the next candidates
+                let contributions_to_upload = self
+                    .next_prs_of_registered_users(&mut next_contributions)
+                    .await;
+
+                if contributions_to_upload.is_empty() {
+                    // No more candidate contribution to upload, we're done
+                    break None;
+                }
+
+                // Make the call to the smart contract
+                let calls = contributions_to_upload
+                    .iter()
+                    .map(|pr| self.oracle.make_add_contribution_call(pr))
+                    .collect::<Vec<_>>();
+
+                let transaction_result = self
+                    .oracle
+                    .send_transaction(&calls)
+                    .await
+                    .map(|res| format!("0x{:x}", res.transaction_hash))
+                    .map_err(anyhow::Error::msg);
+
+                last_transaction_result = Some(transaction_result);
+                contributions_uploaded = contributions_to_upload;
+            }
+        });
+
+        Ok(Streamable::Async(status_stream.into()))
     }
 }

--- a/src/starknet/mod.rs
+++ b/src/starknet/mod.rs
@@ -1,131 +1,58 @@
-use std::env;
-
-use crate::{model::*, traits::logger::*};
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use async_trait::async_trait;
-use log::info;
+
+use log::debug;
+pub use starknet::accounts::Account;
 use starknet::{
-    accounts::{Account, Call, SingleOwnerAccount},
-    core::{
-        chain_id,
-        types::FieldElement,
-        utils::{cairo_short_string_to_felt, get_selector_from_name},
-    },
-    providers::{
-        jsonrpc::{
-            models::{BlockHashOrTag, BlockTag, FunctionCall},
-            HttpTransport, JsonRpcClient,
-        },
-        SequencerGatewayProvider,
-    },
+    accounts::SingleOwnerAccount,
+    core::{chain_id, types::FieldElement},
+    providers::SequencerGatewayProvider,
     signers::{LocalWallet, SigningKey},
 };
-use url::Url;
 
-use self::models::ContractUpdateStatus;
+use self::{
+    github_oracle::{GithubOracle, Oracle},
+    models::ContractUpdateStatus,
+    registry::Registry,
+};
+use crate::{
+    model::pullrequest,
+    traits::Logger,
+};
 
+mod github_oracle;
 pub mod models;
+mod registry;
 
-pub struct API {
-    oracle_contract_address: FieldElement,
-    registry_contract_address: FieldElement,
-    account: SingleOwnerAccount<SequencerGatewayProvider, LocalWallet>,
-    client: JsonRpcClient<HttpTransport>,
+pub fn make_account(private_key: &str, account_address: &str) -> impl Account {
+    let signer = LocalWallet::from(SigningKey::from_secret_scalar(
+        FieldElement::from_hex_be(private_key).unwrap(),
+    ));
+
+    // TODO: make chain_id configurable
+    SingleOwnerAccount::new(
+        SequencerGatewayProvider::starknet_alpha_goerli(),
+        signer,
+        FieldElement::from_hex_be(account_address).unwrap(),
+        chain_id::TESTNET,
+    )
 }
 
-impl API {
-    pub fn new(
-        private_key: &str,
-        account_address: &str,
-        oracle_contract_address: &str,
-        registry_contract_address: &str,
-    ) -> Self {
-        let signer = LocalWallet::from(SigningKey::from_secret_scalar(
-            FieldElement::from_hex_be(private_key).unwrap(),
-        ));
+}
 
-        // TODO: make chain_id configurable
-        let account = SingleOwnerAccount::new(
-            SequencerGatewayProvider::starknet_alpha_goerli(),
-            signer,
-            FieldElement::from_hex_be(account_address).unwrap(),
-            chain_id::TESTNET,
-        );
+pub struct API<'a> {
+    registry: Registry,
+    oracle: Box<dyn Oracle + Sync + Send + 'a>,
+}
 
+impl<'a> API<'a> {
+    pub fn new<A: Account + Sync>(account: &'a A) -> Self {
         Self {
-            oracle_contract_address: FieldElement::from_hex_be(oracle_contract_address).unwrap(),
-            registry_contract_address: FieldElement::from_hex_be(registry_contract_address)
-                .unwrap(),
-            account,
-            client: JsonRpcClient::new(HttpTransport::new(json_rpc_uri())),
-        }
-    }
-}
-
-fn json_rpc_uri() -> Url {
-    Url::parse(&env::var("JSON_RPC_URI").expect("JSON_RPC_URI must be set"))
-        .expect("Invalid JSON_RPC_URI")
-}
-
-impl API {
-    fn make_call(&self, selector: &str, pr: &pullrequest::PullRequest) -> Call {
-        Call {
-            to: self.oracle_contract_address,
-            selector: get_selector_from_name(selector).unwrap(),
-            calldata: make_call_data(pr),
+            registry: Registry::default(),
+            oracle: Box::new(GithubOracle::new(account)),
         }
     }
 
-    // TODO: Turn this function into get_user_information and use it as filter_map
-    async fn is_user_registered(&self, user: &str) -> bool {
-        self.client
-            .call(
-                &FunctionCall {
-                    contract_address: self.registry_contract_address,
-                    entry_point_selector: get_selector_from_name(
-                        "get_user_information_from_github_handle",
-                    )
-                    .unwrap(),
-                    calldata: vec![FieldElement::from_dec_str(&user).unwrap()],
-                },
-                &BlockHashOrTag::Tag(BlockTag::Latest),
-            )
-            .await
-            .is_ok()
-    }
-
-    async fn send_contribution(
-        &self,
-        pr: pullrequest::PullRequest,
-    ) -> Result<ContractUpdateStatus> {
-        info!(
-            "Register contribution #{} by {} ({})",
-            pr.id, pr.author, pr.status
-        );
-
-        let transaction_result = self
-            .account
-            .execute(&[self.make_call("add_contribution_from_handle", &pr)])
-            .send()
-            .await?;
-
-        Ok(ContractUpdateStatus::new(
-            pr.id.clone(),
-            format!("{:x}", transaction_result.transaction_hash),
-        ))
-    }
-}
-
-fn make_call_data(pr: &pullrequest::PullRequest) -> Vec<FieldElement> {
-    let str_to_felt = |value: &String| cairo_short_string_to_felt(&value).unwrap();
-
-    vec![
-        FieldElement::from_dec_str(&pr.author).unwrap(), // github identifier
-        str_to_felt(&String::from("")),                  // owner
-        str_to_felt(&pr.repository_id),                  // repo
-        FieldElement::from_dec_str(&pr.id).unwrap(),     // PR ID
-        FieldElement::from_dec_str(&pr.status.to_string()).unwrap(), // PR status (merged)
-    ]
 }
 
 #[async_trait]

--- a/src/starknet/mod.rs
+++ b/src/starknet/mod.rs
@@ -1,4 +1,4 @@
-use crate::{model::*, traits::logger::Logger};
+use crate::{model::*, traits::logger::*};
 use anyhow::Result;
 use async_trait::async_trait;
 use log::info;
@@ -44,7 +44,7 @@ impl API {
 }
 
 #[async_trait]
-impl Logger<pullrequest::PullRequest, Result<ContractUpdateStatus>> for API {
+impl Logger<pullrequest::PullRequest, ContractUpdateStatus> for API {
     async fn log(&self, pr: pullrequest::PullRequest) -> Result<ContractUpdateStatus> {
         info!(
             "Register contribution #{} by {} ({})",

--- a/src/starknet/registry.rs
+++ b/src/starknet/registry.rs
@@ -1,0 +1,70 @@
+use futures::lock::Mutex;
+use log::debug;
+use starknet::{
+    core::{types::FieldElement, utils::get_selector_from_name},
+    providers::jsonrpc::{
+        models::{BlockHashOrTag, BlockTag, FunctionCall},
+        HttpTransport, JsonRpcClient,
+    },
+};
+use std::collections::{hash_map::Entry, HashMap};
+use url::Url;
+
+pub(super) struct Registry {
+    contract_address: FieldElement,
+    client: JsonRpcClient<HttpTransport>,
+    users: Mutex<HashMap<String, bool>>,
+}
+
+fn json_rpc_uri() -> Url {
+    Url::parse(&std::env::var("JSON_RPC_URI").expect("JSON_RPC_URI must be set"))
+        .expect("Invalid JSON_RPC_URI")
+}
+
+fn registry_contract_address() -> FieldElement {
+    let registry_contract_address =
+        std::env::var("REGISTRY_ADDRESS").expect("REGISTRY_ADDRESS must be set");
+    FieldElement::from_hex_be(&registry_contract_address)
+        .expect("Invalid value for REGISTRY_ADDRESS")
+}
+
+impl Default for Registry {
+    fn default() -> Self {
+        Self {
+            contract_address: registry_contract_address(),
+            client: JsonRpcClient::new(HttpTransport::new(json_rpc_uri())),
+            users: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+impl Registry {
+    // TODO: Turn this function into get_user_information and use it as filter_map
+    pub async fn is_user_registered(&self, user: &str) -> bool {
+        match self.users.lock().await.entry(user.into()) {
+            Entry::Occupied(entry) => entry.get().to_owned(),
+            Entry::Vacant(entry) => entry
+                .insert(self.is_user_registered_in_contract(user).await)
+                .to_owned(),
+        }
+    }
+
+    async fn is_user_registered_in_contract(&self, user: &str) -> bool {
+        debug!("Checking if user {} is registered", user);
+
+        self.client
+            .call(
+                &FunctionCall {
+                    contract_address: self.contract_address,
+                    entry_point_selector: get_selector_from_name(
+                        "get_user_information_from_github_handle",
+                    )
+                    .unwrap(),
+                    calldata: vec![FieldElement::from_dec_str(&user).unwrap()],
+                },
+                &BlockHashOrTag::Tag(BlockTag::Latest),
+            )
+            .await
+            .is_ok()
+    }
+}

--- a/src/traits/logger.rs
+++ b/src/traits/logger.rs
@@ -1,7 +1,16 @@
+use super::{Streamable, StreamableResult};
 use anyhow::Result;
 use async_trait::async_trait;
 
 #[async_trait]
 pub trait Logger<Item, Report> {
     async fn log(&self, item: Item) -> Result<Report>;
+}
+
+#[async_trait]
+pub trait StreamLogger<Item, Report> {
+    async fn log(
+        &self,
+        items: Streamable<'life0, Item>,
+    ) -> Result<StreamableResult<'life0, Report>>;
 }

--- a/src/traits/logger.rs
+++ b/src/traits/logger.rs
@@ -1,6 +1,7 @@
+use anyhow::Result;
 use async_trait::async_trait;
 
 #[async_trait]
 pub trait Logger<Item, Report> {
-    async fn log(&self, item: Item) -> Report;
+    async fn log(&self, item: Item) -> Result<Report>;
 }

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use futures::{stream::BoxStream, Stream, StreamExt};
 
 pub mod fetcher;
@@ -11,6 +12,8 @@ pub enum Streamable<'a, Output> {
     Sync(StreamableSync<'a, Output>),
     Async(StreamableAsync<'a, Output>),
 }
+
+pub type StreamableResult<'a, T> = Streamable<'a, Result<T>>;
 
 impl<'a, Iter, Output> From<Iter> for StreamableSync<'a, Output>
 where


### PR DESCRIPTION
- :recycle: move Result out of Logger return type
- :sparkles: try to upload contribution only if user is registered
- :recycle: extract smart contract interactions from main logic
- :zap: bulk transactions when uploading contributions in smart contract

* Use the JSON RPC interface to perform a contract call to the Badge Registry to check if a given PR author is registered before trying to push its contribution.
* Contributions of all registered are pushed in batches to improve performances

Next step:
* Use the returned user information from this contract call to insert the contribution
* Wait for transaction to be accepted on L2 to send the next one
